### PR TITLE
Added efficiency example

### DIFF
--- a/examples/efficiently_parse_multi_events_and_ticks/index.js
+++ b/examples/efficiently_parse_multi_events_and_ticks/index.js
@@ -1,0 +1,52 @@
+var {parseEvents, parseTicks} = require('@laihoe/demoparser2');
+
+
+const pathToDemo = "/path/to/demfile.dem"
+
+// Define all event names we're interested in
+const eventNames = [
+    "begin_new_match", "round_start", "round_end", "round_mvp", 
+    "player_death", "bomb_planted", "bomb_defused", "hostage_rescued", 
+    "weapon_fire", "flashbang_detonate", "hegrenade_detonate", 
+    "molotov_detonate", "smokegrenade_detonate", "player_hurt", 
+    "player_blind"
+  ];
+  
+  let allEvents = parseEvents(pathToDemo, eventNames,["game_time","team_num"]);  // Fetch all events with any fields needed for any events
+  
+  // Find match start tick by filtering already parsed events
+  const matchStartTick = allEvents.find(event => event.event_name === "begin_new_match")?.tick || 0;
+  const roundStartEvents = allEvents.filter(event => event.event_name === "round_start");
+  const roundEndEvents = allEvents.filter(event => event.event_name === "round_end" && event.tick >= matchStartTick);
+  
+  // Filter out events before the match start (warmup, early rounds before a restart e.g. mp_restartgame on the server)
+  allEvents = allEvents.filter(event => event.tick >= matchStartTick);
+  
+  // Get ticks with metadata only for ticks that match events we are interested in with any fields needed for any ticks
+  const allTicksArray = parseTicks(pathToDemo, 
+    ["equipment_value_this_round", "cash_spent_this_round", "is_alive", "team_num", "player_name", "score", "player_steamid"], 
+    allEvents.map(event => event.tick));  // Fetch all tick data once
+  
+  // Convert the array of tick data into a map for efficient access later
+  const allTicksMap = new Map();
+  allTicksArray.forEach(tick => {
+    if (!allTicksMap.has(tick.tick)) {
+      allTicksMap.set(tick.tick, []);
+    }
+    allTicksMap.get(tick.tick).push(tick);
+  });
+  
+  //then access ticks with get from the map of already parsed ticks with allTicksMap.get()
+  const gameEndTick = Math.max(...roundEndEvents.map(event => event.tick));
+  const scoreboard = allTicksMap.get(gameEndTick) || [];
+
+  // Get the player store status at the end of the game - this will include additional round level fields you can ignore
+  console.log(scoreboard)
+
+  // Get other events by filtering array:
+  let shotEvents = allEvents.filter(event => event.event_name === "weapon_fire");
+  let hitEvents = allEvents.filter(event => event.event_name === "player_hurt");
+  let flashEvents = allEvents.filter(event => event.event_name === "player_blind");
+  // ... do the same for any of the other events from eventNames as needed
+
+  console.log(hitEvents)

--- a/examples/efficiently_parse_multi_events_and_ticks/index.py
+++ b/examples/efficiently_parse_multi_events_and_ticks/index.py
@@ -1,0 +1,46 @@
+from demoparser2 import DemoParser
+
+parser = DemoParser("/path/to/demfile.dem")
+
+event_names = [
+    "begin_new_match", "round_start", "round_end", "round_mvp", 
+    "player_death", "bomb_planted", "bomb_defused", "hostage_rescued", 
+    "weapon_fire", "flashbang_detonate", "hegrenade_detonate", 
+    "molotov_detonate", "smokegrenade_detonate", "player_hurt", 
+    "player_blind"
+]
+
+all_events = parser.parse_events(event_names, other=["game_time", "team_num"])
+
+# Find match start tick
+begin_new_match_df = next((df for event_name, df in all_events if event_name == 'begin_new_match'), None)
+match_start_tick = begin_new_match_df['tick'].iloc[0] if begin_new_match_df is not None else 0
+
+# Filter out events before the match start
+filtered_events = [(event_name, df[df['tick'] >= match_start_tick]) for event_name, df in all_events]
+
+wanted_props = ["equipment_value_this_round", "cash_spent_this_round", "is_alive", "team_num", "player_name", "score", "player_steamid"]
+tick_values = set()
+for _, df in filtered_events:
+    tick_values.update(df['tick'].unique())
+all_ticks = parser.parse_ticks(wanted_props, ticks=list(tick_values))
+
+# Convert ticks to a map
+all_ticks_map = {}
+for tick in all_ticks.itertuples():
+    if tick.tick not in all_ticks_map:
+        all_ticks_map[tick.tick] = []
+    all_ticks_map[tick.tick].append(tick)
+
+# Access ticks
+game_end_events = next((df for event_name, df in filtered_events if event_name == 'round_end'), None)
+game_end_tick = max(game_end_events['tick']) if game_end_events is not None else 0
+scoreboard = all_ticks_map.get(game_end_tick, [])
+
+# Additional processing for other events
+shot_events = next((df for event_name, df in filtered_events if event_name == 'weapon_fire'), None)
+hit_events = next((df for event_name, df in filtered_events if event_name == 'player_hurt'), None)
+flash_events = next((df for event_name, df in filtered_events if event_name == 'player_blind'), None)
+
+print(scoreboard)
+print(hit_events)


### PR DESCRIPTION
These examples cover an efficient way to parse multiple events and their associated ticks with the minimum number of calls to parseEvent(s) and parseTicks.  The ticks are read into a map for efficient access later.  Just update the eventNames and field arrays for Events and ticks - then filter allEvents based on the events you need later in the process and retrieve ticks from the map.