### PR TITLE
Listen for round_start_time to change to trigger FreezePeriodStart

### DIFF
--- a/src/parser/src/first_pass/prop_controller.rs
+++ b/src/parser/src/first_pass/prop_controller.rs
@@ -421,6 +421,7 @@ impl PropController {
         } else {
             match name {
                 "CCSGameRulesProxy.CCSGameRules.m_bFreezePeriod" => self.special_ids.is_freeze_period = Some(id),
+                "CCSGameRulesProxy.CCSGameRules.m_fRoundStartTime" => self.special_ids.round_start_time = Some(id),
                 "CCSGameRulesProxy.CCSGameRules.m_eRoundWinReason" => self.special_ids.round_win_reason = Some(id),
                 "CCSGameRulesProxy.CCSGameRules.m_totalRoundsPlayed" => self.special_ids.total_rounds_played = Some(id),
                 "CCSTeam.m_iTeamNum" => self.special_ids.team_team_num = Some(id),

--- a/src/parser/src/second_pass/entities.rs
+++ b/src/parser/src/second_pass/entities.rs
@@ -361,11 +361,9 @@ impl<'a> SecondPassParser<'a> {
                 }
             }
             // freeze period end
-            if let Some(id) = prop_controller.special_ids.is_freeze_period {
+            if let Some(id) = prop_controller.special_ids.round_start_time {
                 if fi.prop_id == id {
-                    if let Variant::Bool(true) = result {
-                        events.push(GameEventInfo::FreezePeriodStart(true));
-                    }
+                    events.push(GameEventInfo::FreezePeriodStart(true));
                 }
             }
         }

--- a/src/parser/src/second_pass/parser_settings.rs
+++ b/src/parser/src/second_pass/parser_settings.rs
@@ -243,11 +243,13 @@ pub struct SpecialIDs {
 
     pub round_win_reason: Option<u32>,
     pub is_freeze_period: Option<u32>,
+    pub round_start_time: Option<u32>,
 }
 impl SpecialIDs {
     pub fn new() -> Self {
         SpecialIDs {
             is_freeze_period: None,
+            round_start_time: None,
             round_win_reason: None,
             total_rounds_played: None,
             h_owner_entity: None,


### PR DESCRIPTION
This prevents a bug in which round_start and round_officially_ended are called one more time than were traditionally in prior versions. This way of tracking is more consistent with the prior event calls.