### PR TITLE
Try to improve rust code readability

### DIFF
--- a/src/parser/Cargo.lock
+++ b/src/parser/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
+checksum = "0bcc343da15609eaecd65f8aa76df8dc4209d325131d8219358c0aaaebab0bf6"
 dependencies = [
  "bytes",
  "once_cell",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
+checksum = "f0766e3675a627c327e4b3964582594b0e8741305d628a98a5de75a1d15f99b9"
 dependencies = [
  "thiserror",
 ]

--- a/src/parser/src/first_pass/frameparser.rs
+++ b/src/parser/src/first_pass/frameparser.rs
@@ -55,9 +55,9 @@ impl FrameParser {
             frame_ends_at: ptr,
             size: size as usize,
             tick: tick as i32,
-            frame_starts_at: frame_starts_at,
-            is_compressed: is_compressed,
-            demo_cmd: demo_cmd,
+            frame_starts_at,
+            is_compressed,
+            demo_cmd,
         })
     }
     #[inline(always)]
@@ -75,9 +75,9 @@ impl FrameParser {
             frame_ends_at: *ptr,
             size: size as usize,
             tick: tick as i32,
-            frame_starts_at: frame_starts_at,
-            is_compressed: is_compressed,
-            demo_cmd: demo_cmd,
+            frame_starts_at,
+            is_compressed,
+            demo_cmd,
         })
     }
 

--- a/src/parser/src/first_pass/parser.rs
+++ b/src/parser/src/first_pass/parser.rs
@@ -126,9 +126,9 @@ impl<'a> FirstPassParser<'a> {
 
         Ok(Frame {
             size: size as usize,
-            frame_starts_at: frame_starts_at,
-            is_compressed: is_compressed,
-            demo_cmd: demo_cmd,
+            frame_starts_at,
+            is_compressed,
+            demo_cmd,
             tick: self.tick,
         })
     }

--- a/src/parser/src/first_pass/prop_controller.rs
+++ b/src/parser/src/first_pass/prop_controller.rs
@@ -133,19 +133,19 @@ impl PropController {
     ) -> Self {
         PropController {
             id: NORMAL_PROP_BASEID,
-            wanted_player_props: wanted_player_props,
+            wanted_player_props,
             wanted_prop_ids: vec![],
             prop_infos: vec![],
             name_to_id: AHashMap::default(),
             special_ids: SpecialIDs::new(),
             id_to_name: AHashMap::default(),
             name_to_special_id: AHashMap::default(),
-            wanted_other_props: wanted_other_props,
-            real_name_to_og_name: real_name_to_og_name,
+            wanted_other_props,
+            real_name_to_og_name,
             event_with_velocity: !wanted_events.is_empty() && needs_velocty,
             path_to_name: AHashMap::default(),
             needs_velocity: needs_velocty,
-            wanted_prop_states: wanted_prop_states,
+            wanted_prop_states,
             wanted_prop_state_infos: vec![],
         }
     }
@@ -442,7 +442,7 @@ impl PropController {
             };
         }
     }
-    fn traverse_fields(&mut self, fields: &mut Vec<Field>, ser_name: String, path_og: Vec<i32>) {
+    fn traverse_fields(&mut self, fields: &mut [Field], ser_name: String, path_og: Vec<i32>) {
         for (idx, f) in fields.iter_mut().enumerate() {
             let mut path = path_og.clone();
             path.push(idx as i32);

--- a/src/parser/src/second_pass/collect_data.rs
+++ b/src/parser/src/second_pass/collect_data.rs
@@ -285,8 +285,8 @@ impl<'a> SecondPassParser<'a> {
             };
 
             self.projectile_records.push(ProjectileRecord {
-                steamid: steamid,
-                name: name,
+                steamid,
+                name,
                 x: float_x,
                 y: float_y,
                 z: float_z,
@@ -1010,10 +1010,10 @@ impl<'a> SecondPassParser<'a> {
                 self.players.insert(
                     e,
                     PlayerMetaData {
-                        name: name,
-                        team_num: team_num,
+                        name,
+                        team_num,
                         player_entity_id: player_entid,
-                        steamid: steamid,
+                        steamid,
                         controller_entid: Some(*entity_id),
                     },
                 );

--- a/src/parser/src/second_pass/entities.rs
+++ b/src/parser/src/second_pass/entities.rs
@@ -315,9 +315,9 @@ impl<'a> SecondPassParser<'a> {
         };
         let entity = Entity {
             entity_id: *entity_id,
-            cls_id: cls_id,
+            cls_id,
             props: AHashMap::with_capacity(0),
-            entity_type: entity_type,
+            entity_type,
         };
         if self.entities.len() as i32 <= *entity_id {
             // if corrupt, this can cause oom allocations

--- a/src/parser/src/second_pass/game_events.rs
+++ b/src/parser/src/second_pass/game_events.rs
@@ -432,7 +432,7 @@ impl<'a> SecondPassParser<'a> {
         };
         EventField {
             name: prefix.to_owned() + "_steamid",
-            data: data,
+            data,
         }
     }
     pub fn player_from_steamid32(&self, steamid32: i32) -> Option<i32> {
@@ -476,7 +476,7 @@ impl<'a> SecondPassParser<'a> {
             fields.extend(self.find_non_player_props());
             let ge = GameEvent {
                 name: "server_cvar".to_string(),
-                fields: fields,
+                fields,
                 tick: self.tick,
             };
             self.game_events.push(ge);
@@ -575,7 +575,7 @@ impl<'a> SecondPassParser<'a> {
                     fields.extend(self.find_non_player_props());
                     let ge = GameEvent {
                         name: "item_sold".to_string(),
-                        fields: fields,
+                        fields,
                         tick: self.tick,
                     };
                     self.game_events.push(ge);
@@ -742,7 +742,7 @@ impl<'a> SecondPassParser<'a> {
                         fields.extend(self.find_non_player_props());
                         let ge = GameEvent {
                             name: "item_purchase".to_string(),
-                            fields: fields,
+                            fields,
                             tick: self.tick,
                         };
                         self.game_events.push(ge);
@@ -819,7 +819,7 @@ impl<'a> SecondPassParser<'a> {
             });
             let ge = GameEvent {
                 name: "round_end".to_string(),
-                fields: fields,
+                fields,
                 tick: self.tick,
             };
             self.game_events.push(ge);
@@ -855,7 +855,7 @@ impl<'a> SecondPassParser<'a> {
         });
         let ge = GameEvent {
             name: "round_officially_ended".to_string(),
-            fields: fields,
+            fields,
             tick: self.tick,
         };
         self.game_events.push(ge);
@@ -879,7 +879,7 @@ impl<'a> SecondPassParser<'a> {
         });
         let ge = GameEvent {
             name: "cs_win_panel_match".to_string(),
-            fields: fields,
+            fields,
             tick: self.tick,
         };
         self.game_events.push(ge);
@@ -929,7 +929,7 @@ impl<'a> SecondPassParser<'a> {
         fields.extend(self.find_non_player_props());
         let ge = GameEvent {
             name: "chat_message".to_string(),
-            fields: fields,
+            fields,
             tick: self.tick,
         };
         self.game_events.push(ge);
@@ -956,7 +956,7 @@ impl<'a> SecondPassParser<'a> {
         fields.extend(self.find_non_player_props());
         let ge = GameEvent {
             name: "server_message".to_string(),
-            fields: fields,
+            fields,
             tick: self.tick,
         };
         self.game_events.push(ge);
@@ -981,7 +981,7 @@ impl<'a> SecondPassParser<'a> {
         fields.extend(self.find_non_player_props());
         let ge = GameEvent {
             name: "round_start".to_string(),
-            fields: fields,
+            fields,
             tick: self.tick,
         };
         self.game_events.push(ge);
@@ -1037,7 +1037,7 @@ impl<'a> SecondPassParser<'a> {
             fields.extend(self.find_non_player_props());
             let ge = GameEvent {
                 name: "rank_update".to_string(),
-                fields: fields,
+                fields,
                 tick: self.tick,
             };
             self.game_events.push(ge);

--- a/src/parser/src/second_pass/other_netmessages.rs
+++ b/src/parser/src/second_pass/other_netmessages.rs
@@ -31,7 +31,7 @@ impl<'a> SecondPassParser<'a> {
                 Some(name) => Some(name.to_string()),
                 None => None,
             };
-            self.item_drops.push(EconItem { account_id: item.accountid, item_id: item.itemid, def_index: item.defindex, paint_index: item.paintindex, rarity: item.rarity, quality: item.quality, paint_seed: item.paintseed, paint_wear: item.paintwear, quest_id: item.questid, dropreason: item.dropreason, custom_name: item.customname.clone(), inventory: item.inventory, ent_idx: item.entindex, steamid: None, item_name: item_name, skin_name: skin_name });
+            self.item_drops.push(EconItem { account_id: item.accountid, item_id: item.itemid, def_index: item.defindex, paint_index: item.paintindex, rarity: item.rarity, quality: item.quality, paint_seed: item.paintseed, paint_wear: item.paintwear, quest_id: item.questid, dropreason: item.dropreason, custom_name: item.customname.clone(), inventory: item.inventory, ent_idx: item.entindex, steamid: None, item_name, skin_name });
         }
         Ok(())
     }
@@ -70,7 +70,7 @@ impl<'a> SecondPassParser<'a> {
                         Some(name) => Some(name.to_string()),
                         None => None,
                     };
-                    self.skins.push(EconItem { account_id: item.accountid, item_id: item.itemid, def_index: item.defindex, paint_index: item.paintindex, rarity: item.rarity, quality: item.quality, paint_seed: item.paintseed, paint_wear: item.paintwear, quest_id: item.questid, dropreason: item.dropreason, custom_name: item.customname.clone(), inventory: item.inventory, ent_idx: item.entindex, steamid: player.xuid, item_name: item_name, skin_name: skin_name });
+                    self.skins.push(EconItem { account_id: item.accountid, item_id: item.itemid, def_index: item.defindex, paint_index: item.paintindex, rarity: item.rarity, quality: item.quality, paint_seed: item.paintseed, paint_wear: item.paintwear, quest_id: item.questid, dropreason: item.dropreason, custom_name: item.customname.clone(), inventory: item.inventory, ent_idx: item.entindex, steamid: player.xuid, item_name, skin_name });
                 }
             }
         }

--- a/src/parser/src/second_pass/parser.rs
+++ b/src/parser/src/second_pass/parser.rs
@@ -123,9 +123,9 @@ impl<'a> SecondPassParser<'a> {
 
         Ok(Frame {
             size: size as usize,
-            frame_starts_at: frame_starts_at,
-            is_compressed: is_compressed,
-            demo_cmd: demo_cmd,
+            frame_starts_at,
+            is_compressed,
+            demo_cmd,
             tick: self.tick,
         })
     }


### PR DESCRIPTION
As suggested in issue #218 

# Type of changes
- Try to flatten code by using early returns/continues if there is only a single happy path in a function or loop
- Change repetitive matches with map_err
- Change matches returning true/false with matches! macro