### PR TITLE
maturin fixes

### DIFF
--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -21,6 +21,3 @@ path = "./csgoproto"
 
 [profile.dev]
 overflow-checks = false
-
-[tool.maturin]
-python-source = "src/python"

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "demoparser2"
+dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = ["pandas>=1.5.0", "numpy", "polars", "pyarrow", "tqdm"]
 classifiers = [


### PR DESCRIPTION
- The `tool.maturin.python-source` path is invalid, as can be seen here: https://github.com/LaihoE/demoparser/actions/runs/11539521095/job/32119277337?pr=225#step:6:271. Since https://github.com/PyO3/maturin/pull/2343, this is a fatal error in maturin. This change removes the field altogether.
- Since https://github.com/PyO3/maturin/pull/2391, maturin does not automatically fill in `project.version` if it's missing in `pyproject.toml`. `dynamic = ["version"]` restores the old behavior.

Without these changes, the project doesn't build on maturin v1.7.7 and higher.