### PR TITLE
Expand stub testing and expose WantedPropStatus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install maturin patchelf mypy
+          pip install maturin patchelf mypy pandas-stubs
 
           maturin develop
           python3 tests/signature_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install pytest maturin patchelf
+          pip install maturin patchelf mypy
 
           maturin develop
           python3 tests/signature_tests.py
+          python3 -m mypy.stubtest demoparser2 --allowlist tests/mypy-stubtest-allowlist.txt

--- a/src/python/demoparser2.pyi
+++ b/src/python/demoparser2.pyi
@@ -1,9 +1,23 @@
 import pandas as pd
-from typing import Dict, Sequence, Optional, List, Tuple, final, Union
+from typing import (
+    Dict,
+    Sequence,
+    Optional,
+    List,
+    Tuple,
+    final,
+    Union,
+    Protocol,
+    type_check_only,
+)
+
+@type_check_only
+class WantedPropStateProtocol(Protocol):
+    prop: str
+    state: Union[bool, str, int, float]
 
 @final
 class WantedPropState:
-
     def __init__(self, prop: str, state: Union[bool, str, int, float]) -> None: ...
 
 @final
@@ -37,7 +51,7 @@ class DemoParser:
         *,
         players: Optional[Sequence[int]] = None,
         ticks: Optional[Sequence[int]] = None,
-        prop_states: Optional[Sequence[WantedPropState]] = None,
+        prop_states: Optional[Sequence[WantedPropStateProtocol | WantedPropState]] = None,
     ) -> pd.DataFrame:
         """Parse the specified props.
 

--- a/src/python/demoparser2.pyi
+++ b/src/python/demoparser2.pyi
@@ -1,6 +1,12 @@
 import pandas as pd
-from typing import Dict, Sequence, Optional, List, Tuple
+from typing import Dict, Sequence, Optional, List, Tuple, final, Union
 
+@final
+class WantedPropState:
+
+    def __init__(self, prop: str, state: Union[bool, str, int, float]) -> None: ...
+
+@final
 class DemoParser:
     def __init__(self, path: str) -> None: ...
     def parse_header(self) -> Dict[str, str]: ...
@@ -13,12 +19,14 @@ class DemoParser:
     def parse_event(
         self,
         event_name: str,
+        *,
         player: Optional[Sequence[str]] = None,
         other: Optional[Sequence[str]] = None,
     ) -> pd.DataFrame: ...
     def parse_events(
         self,
         event_name: Sequence[str],
+        *,
         player: Optional[Sequence[str]] = None,
         other: Optional[Sequence[str]] = None,
     ) -> List[Tuple[str, pd.DataFrame]]: ...
@@ -26,8 +34,10 @@ class DemoParser:
     def parse_ticks(
         self,
         wanted_props: Sequence[str],
+        *,
         players: Optional[Sequence[int]] = None,
         ticks: Optional[Sequence[int]] = None,
+        prop_states: Optional[Sequence[WantedPropState]] = None,
     ) -> pd.DataFrame:
         """Parse the specified props.
 
@@ -41,3 +51,5 @@ class DemoParser:
         Returns:
             pd.DataFrame: Dataframe of all the parsed props for each player at each tick.
         """
+
+__all__ = ["DemoParser", "WantedPropState"]

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use pyo3::create_exception;
 create_exception!(DemoParser, Exception, pyo3::exceptions::PyException);
 
+#[derive(Clone)]
 struct PyVariant(Variant);
 
 impl<'source> FromPyObject<'source> for PyVariant {
@@ -62,10 +63,19 @@ impl<'source> FromPyObject<'source> for PyVariant {
     }
 }
 
-#[derive(FromPyObject)]
+#[pyclass]
+#[derive(Clone)]
 struct WantedPropState {
     prop: String,
     state: PyVariant,
+}
+
+#[pymethods]
+impl WantedPropState {
+    #[new]
+    fn new(prop: String, state: PyVariant) -> Self {
+        Self { prop, state }
+    }
 }
 
 #[pymethods]
@@ -1147,5 +1157,6 @@ fn find_type_of_vals(pairs: &Vec<&EventField>) -> Result<Option<Variant>, DemoPa
 #[pymodule]
 fn demoparser2(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DemoParser>()?;
+    m.add_class::<WantedPropState>()?;
     Ok(())
 }

--- a/src/python/tests/mypy-stubtest-allowlist.txt
+++ b/src/python/tests/mypy-stubtest-allowlist.txt
@@ -1,0 +1,1 @@
+demoparser2.demoparser2

--- a/src/python/tests/signature_tests.py
+++ b/src/python/tests/signature_tests.py
@@ -1,10 +1,17 @@
 import unittest
 from unittest import TestCase
+from typing import Union
 
 import pandas as pd
 from demoparser2 import DemoParser, WantedPropState
 
 demo_path = "../parser/test_demo.dem"
+
+
+class MyWantedPropState:
+    def __init__(self, prop: str, state: Union[bool, str, int, float]):
+        self.prop = prop
+        self.state = state
 
 
 class SignatureTest(TestCase):
@@ -137,6 +144,14 @@ class SignatureTest(TestCase):
             ],
         )
 
+        parser.parse_ticks(
+            ["X", "Y"],
+            prop_states=[
+                MyWantedPropState("is_alive", True),
+                MyWantedPropState("is_bomb_planted", True),
+            ],
+        )
+
         with self.assertRaises(TypeError):
             parser.parse_ticks(["X", "Y"], players=5, ticks=None)
 
@@ -149,7 +164,7 @@ class SignatureTest(TestCase):
         with self.assertRaises(TypeError):
             parser.parse_ticks(5)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             parser.parse_ticks(
                 ["X", "Y"], prop_states=[{"prop": "is_alive", "state": True}]
             )

--- a/src/python/tests/signature_tests.py
+++ b/src/python/tests/signature_tests.py
@@ -2,14 +2,9 @@ import unittest
 from unittest import TestCase
 
 import pandas as pd
-from demoparser2 import DemoParser
+from demoparser2 import DemoParser, WantedPropState
 
 demo_path = "../parser/test_demo.dem"
-
-class WantedPropState:
-    def __init__(self, prop, state):
-        self.prop = prop
-        self.state = state
 
 
 class SignatureTest(TestCase):
@@ -134,7 +129,13 @@ class SignatureTest(TestCase):
         parser.parse_ticks(["X", "Y"], players=[1, 2, 3], ticks=[1, 2, 3])
         parser.parse_ticks(["X", "Y"], players=None, ticks=None)
         parser.parse_ticks(["X", "Y"], players=[], ticks=[])
-        parser.parse_ticks(["X", "Y"], prop_states=[WantedPropState("is_alive", True), WantedPropState("is_bomb_planted", True)])
+        parser.parse_ticks(
+            ["X", "Y"],
+            prop_states=[
+                WantedPropState("is_alive", True),
+                WantedPropState("is_bomb_planted", True),
+            ],
+        )
 
         with self.assertRaises(TypeError):
             parser.parse_ticks(["X", "Y"], players=5, ticks=None)
@@ -148,9 +149,10 @@ class SignatureTest(TestCase):
         with self.assertRaises(TypeError):
             parser.parse_ticks(5)
 
-        with self.assertRaises(AttributeError):
-            parser.parse_ticks(["X", "Y"], prop_states=[{"prop": "is_alive", "state": True}])
-
+        with self.assertRaises(TypeError):
+            parser.parse_ticks(
+                ["X", "Y"], prop_states=[{"prop": "is_alive", "state": True}]
+            )
 
     def test_list_updated_fields(self):
         parser = DemoParser(demo_path)


### PR DESCRIPTION
Fix some issues in the stubs and added mypy for stubtesting in the CI.

I also made the `WantedPropState` be directly exposed to python. But note that this is a breaking change, because until now you could define any class (or object) where `getattr("prop")` gave something that could turn into a string and `getattr(state)` could turn into a `PyVariant`, now you need to import `WantedPropState` from demoparser2. But it is probably still a plus for people that want to use it.

But should probably still check with the guy who originally added this since he is probably a user.