### PR TITLE
refactor: improve performance when parsing header

### DIFF
--- a/src/node/src/lib.rs
+++ b/src/node/src/lib.rs
@@ -159,6 +159,7 @@ pub fn parse_voice(path_or_buf: Either<String, Buffer>) -> napi::Result<HashMap<
     huffman_lookup_table: &vec![],
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -194,6 +195,7 @@ pub fn list_game_events(path_or_buf: Either<String, Buffer>) -> napi::Result<Val
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -238,6 +240,7 @@ pub fn parse_grenades(
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -286,6 +289,7 @@ pub fn parse_header(path_or_buf: Either<String, Buffer>) -> napi::Result<Value> 
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -359,6 +363,7 @@ pub fn parse_event(
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: game_event_list_bytes,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -430,6 +435,7 @@ pub fn parse_events(
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: game_event_list_bytes,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -509,6 +515,7 @@ pub fn parse_ticks(
     huffman_lookup_table: &huf,
     order_by_steamid: order_by_steamid,
     fallback_bytes: None,
+    parse_grenades: false
   };
 
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
@@ -583,6 +590,7 @@ pub fn parse_player_info(path_or_buf: Either<String, Buffer>) -> napi::Result<Va
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -614,6 +622,7 @@ pub fn parse_player_skins(path_or_buf: Either<String, Buffer>) -> napi::Result<V
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;
@@ -644,6 +653,7 @@ pub fn list_updated_fields(path_or_buf: Either<String, Buffer>) -> napi::Result<
     huffman_lookup_table: &huf,
     order_by_steamid: false,
     fallback_bytes: None,
+    parse_grenades: false
   };
   let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
   let output = parse_demo(bytes, &mut parser)?;

--- a/src/parser/src/first_pass/parser.rs
+++ b/src/parser/src/first_pass/parser.rs
@@ -78,6 +78,16 @@ pub struct Frame {
 }
 
 impl<'a> FirstPassParser<'a> {
+    pub fn parse_header_only(&mut self, demo_bytes: &'a [u8]) -> Result<AHashMap<String, String>, DemoParserError> {
+        self.handle_short_header(demo_bytes.len(), &demo_bytes[..HEADER_ENDS_AT_BYTE])?;
+        let frame = self.read_frame(demo_bytes)?;
+        let bytes = self.slice_packet_bytes(demo_bytes, frame.size)?;
+        if frame.demo_cmd != EDemoCommands::DemFileHeader {
+            return Err(DemoParserError::MalformedMessage)
+        }
+        self.parse_header(bytes)?;
+        Ok(self.header.clone())
+    }
     pub fn parse_demo(&mut self, demo_bytes: &'a [u8], exit_early: bool) -> Result<FirstPassOutput, DemoParserError> {
         self.handle_short_header(demo_bytes.len(), &demo_bytes[..HEADER_ENDS_AT_BYTE])?;
         let mut reuseable_buffer = vec![0_u8; 100_000];

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -4,6 +4,7 @@ use memmap2::Mmap;
 use parser::first_pass::parser_settings::create_mmap;
 use parser::first_pass::parser_settings::rm_map_user_friendly_names;
 use parser::first_pass::parser_settings::rm_user_friendly_names;
+use parser::first_pass::parser_settings::FirstPassParser;
 use parser::first_pass::parser_settings::ParserInputs;
 use parser::first_pass::read_bits::DemoParserError;
 use parser::parse_demo::Parser;
@@ -140,15 +141,12 @@ impl DemoParser {
             order_by_steamid: false,
             fallback_bytes: None,
         };
-        let mut parser = Parser::new(settings, parser::parse_demo::ParsingMode::Normal);
-        let output = match parser.parse_demo(&self.mmap) {
+        let mut parser = FirstPassParser::new(&settings);
+        let output = match parser.parse_header_only(&self.mmap) {
             Ok(output) => output,
             Err(e) => return Err(Exception::new_err(format!("{e}"))),
         };
-        Ok(output
-            .header
-            .unwrap_or_else(AHashMap::default)
-            .to_object(py))
+        Ok(output.to_object(py))
     }
     /// Returns the names of game events present in the demo
     pub fn list_updated_fields(&self, _py: Python<'_>) -> PyResult<Py<PyAny>> {

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -59,6 +59,7 @@ pub fn parseEvent(
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -123,6 +124,7 @@ pub fn parseEvents(
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -155,6 +157,7 @@ pub fn listGameEvents(fileBytes: Vec<u8>) -> Result<JsValue, JsError> {
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -187,6 +190,7 @@ pub fn listUpdatedFields(fileBytes: Vec<u8>) -> Result<JsValue, JsError> {
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -249,6 +253,7 @@ pub fn parseTicks(
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -316,6 +321,7 @@ pub fn parseGrenades(file: Vec<u8>, extra: Option<Vec<JsValue>>) -> Result<JsVal
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
 
@@ -357,6 +363,7 @@ pub fn parseHeader(file: Vec<u8>) -> Result<JsValue, JsError> {
         order_by_steamid: false,
         wanted_prop_states: HashMap::default().into(),
         fallback_bytes: None,
+        parse_grenades: false
     };
     let mut parser = Parser::new(settings, ForceSingleThreaded);
     let output = match parser.parse_demo(&file) {

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -1,4 +1,5 @@
 use parser::first_pass::parser_settings::rm_user_friendly_names;
+use parser::first_pass::parser_settings::FirstPassParser;
 use parser::first_pass::parser_settings::ParserInputs;
 use parser::parse_demo::Parser;
 use parser::parse_demo::ParsingMode::ForceSingleThreaded;
@@ -365,15 +366,10 @@ pub fn parseHeader(file: Vec<u8>) -> Result<JsValue, JsError> {
         fallback_bytes: None,
         parse_grenades: false
     };
-    let mut parser = Parser::new(settings, ForceSingleThreaded);
-    let output = match parser.parse_demo(&file) {
-        Ok(output) => output,
-        Err(e) => return Err(JsError::new(&format!("{}", e))),
-    };
+    let mut parser = FirstPassParser::new(&settings);
+    let output = parser.parse_header_only(&file).unwrap();
     let mut hm: HashMap<String, String> = HashMap::default();
-    if let Some(header) = output.header {
-        hm.extend(header);
-    }
+    hm.extend(output);
     match serde_wasm_bindgen::to_value(&hm) {
         Ok(s) => Ok(s),
         Err(e) => return Err(JsError::new(&format!("{}", e))),


### PR DESCRIPTION
Currently parser loops over entire file when parsing headers, which adds a lot of overhead.
Solution is to actually only parse header without reading entire file.

Speed improvements on 300mb demo:
In rust it goes from ~100ms to ~0.5ms
In node to ~4ms 
In wasm to ~50ms

Also this PR fixes builds for node and wasm, because in https://github.com/LaihoE/demoparser/pull/276 the bindings were not updated. **But I didn't expose new feature in node/wasm. It's only for build to not fail.**