### PR TITLE
fix: restore player metadata sync in gather_extra_info()

### DIFF
--- a/src/parser/src/second_pass/collect_data.rs
+++ b/src/parser/src/second_pass/collect_data.rs
@@ -1079,6 +1079,60 @@ impl<'a> SecondPassParser<'a> {
                 }
             }
         }
+        if entity.entity_type == EntityType::PlayerController {
+            let team_num = match self.prop_controller.special_ids.teamnum {
+                Some(team_num_id) => match self.get_prop_from_ent(&team_num_id, entity_id) {
+                    Ok(Variant::U32(team_num)) => Some(team_num),
+                    Ok(_) => return Err(DemoParserError::IncorrectMetaDataProp),
+                    Err(_) => None,
+                },
+                _ => None,
+            };
+            let name = match self.prop_controller.special_ids.player_name {
+                Some(id) => match self.get_prop_from_ent(&id, entity_id) {
+                    Ok(Variant::String(name)) => Some(name),
+                    Ok(_) => return Err(DemoParserError::IncorrectMetaDataProp),
+                    Err(_) => None,
+                },
+                _ => None,
+            };
+            let steamid = match self.prop_controller.special_ids.steamid {
+                Some(id) => match self.get_prop_from_ent(&id, entity_id) {
+                    Ok(Variant::U64(sid)) => Some(sid),
+                    Ok(_) => return Err(DemoParserError::IncorrectMetaDataProp),
+                    Err(_) => None,
+                },
+                _ => None,
+            };
+            let player_entid = match self.prop_controller.special_ids.player_pawn {
+                Some(id) => match self.get_prop_from_ent(&id, entity_id) {
+                    Ok(Variant::U32(handle)) => Some((handle & 0x7FF) as i32),
+                    Ok(_) => return Err(DemoParserError::IncorrectMetaDataProp),
+                    Err(_) => None,
+                },
+                _ => None,
+            };
+            if let Some(e) = player_entid {
+                if e != PLAYER_ENTITY_HANDLE_MISSING && steamid != Some(0) && team_num != Some(SPECTATOR_TEAM_NUM) {
+                    match self.should_remove(steamid) {
+                        Some(eid) => {
+                            self.players.remove(&eid);
+                        }
+                        None => {}
+                    }
+                    self.players.insert(
+                        e,
+                        PlayerMetaData {
+                            name,
+                            team_num,
+                            player_entity_id: player_entid,
+                            steamid,
+                            controller_entid: Some(*entity_id),
+                        },
+                    );
+                }
+            }
+        }
         Ok(())
     }
     pub fn should_remove(&self, steamid: Option<u64>) -> Option<i32> {


### PR DESCRIPTION
## Summary

- Restores player metadata population in `gather_extra_info()` that was removed in #311, fixing a v0.41.0 regression on overtime demos
- Fixes null victim damage events, incorrect side attribution, and missing player rounds caused by stale `self.players` when fullpackets are skipped or delta updates don't trigger `PlayerConnect` events
- `handle_player_connect()` is kept as-is (the redundant `self.players.insert()` is idempotent)

Fixes #314

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 333 tests pass
- [ ] Parse overtime demo from #314 and verify:
  - All 10 players appear in all 30 rounds
  - No damage events with null `victim_name`/`victim_steamid`
  - ADR values match v0.40.3
  - Team attribution is correct (`attacker_side != victim_side` filter gives expected ADR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)