### PR TITLE
Return an empty DataFrame when parse_event has no rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install "maturin>=1.0,<1.8" patchelf mypy pandas-stubs
+          pip install maturin patchelf mypy pandas-stubs
 
           maturin develop
           python3 tests/signature_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install maturin patchelf mypy pandas-stubs
+          pip install "maturin>=1.0,<1.8" patchelf mypy pandas-stubs
 
           maturin develop
           python3 tests/signature_tests.py

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -28,7 +28,6 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
-use pyo3::types::PyList;
 use pyo3::IntoPyObjectExt;
 use pyo3::{intern, Python};
 use pyo3::{PyAny, PyResult};
@@ -37,6 +36,12 @@ use std::sync::Arc;
 
 use pyo3::create_exception;
 create_exception!(DemoParser, Exception, pyo3::exceptions::PyException);
+
+fn empty_pandas_dataframe(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    let pandas = py.import("pandas")?;
+    let df = pandas.call_method0("DataFrame")?;
+    df.into_py_any(py)
+}
 
 #[derive(Clone)]
 struct PyVariant(Variant);
@@ -594,7 +599,8 @@ impl DemoParser {
         };
         let event_series = match series_from_event(&output.game_events, py) {
             Ok(ser) => ser,
-            Err(_e) => return Ok(PyList::empty(py).into()),
+            Err(DemoParserError::NoEvents) => return empty_pandas_dataframe(py),
+            Err(e) => return Err(Exception::new_err(format!("{e}"))),
         };
         Ok(event_series)
     }

--- a/src/python/tests/signature_tests.py
+++ b/src/python/tests/signature_tests.py
@@ -94,6 +94,14 @@ class SignatureTest(TestCase):
         with self.assertRaises(TypeError):
             parser.parse_event(5)
 
+    def test_parse_event_without_matching_rows_returns_empty_dataframe(self):
+        parser = DemoParser(demo_path)
+
+        event = parser.parse_event("chat_message")
+
+        self.assertIsInstance(event, pd.DataFrame)
+        self.assertTrue(event.empty)
+
     def test_parse_events_signature(self):
         parser = DemoParser(demo_path)
 


### PR DESCRIPTION
## Summary
- return an empty pandas DataFrame from the Python binding when `parse_event()` finds no matching events
- preserve exception propagation for real serialization/parsing errors instead of collapsing everything into `[]`
- add a regression test covering an event name that is absent from `test_demo.dem`

## Why
When an event is not present in a demo, the Python binding currently converts `DemoParserError::NoEvents` into `[]`. That makes `parse_event()` unstable at the type level: for example `bomb_begindefuse` can return a DataFrame on one demo and a list on another. This change keeps the return type consistent with the documented Python API.

## Validation
- `python3 -m unittest tests.signature_tests.SignatureTest.test_parse_event_without_matching_rows_returns_empty_dataframe tests.signature_tests.SignatureTest.test_parse_event_signature`
- manual check against a FACEIT demo where `bomb_begindefuse` is absent now returns `pandas.DataFrame` with `empty == True` instead of `[]`
