### PR TITLE
Support Anim Graph 2 demos (CGlobalSymbol + CUtlBinaryBlock)

### DIFF
--- a/src/parser/src/maps.rs
+++ b/src/parser/src/maps.rs
@@ -101,6 +101,7 @@ pub static BASETYPE_DECODERS: phf::Map<&'static str, Decoder> = phf_map! {
     "CUtlString" =>           StringDecoder,
     "CUtlStringToken" =>      UnsignedDecoder,
     "CUtlSymbolLarge" =>      StringDecoder,
+    "CGlobalSymbol" => StringDecoder,
     "Quaternion" => NoscaleDecoder,
     "CTransform" => NoscaleDecoder,
     "HSequence" => Unsigned64Decoder,

--- a/src/parser/src/maps.rs
+++ b/src/parser/src/maps.rs
@@ -102,6 +102,7 @@ pub static BASETYPE_DECODERS: phf::Map<&'static str, Decoder> = phf_map! {
     "CUtlStringToken" =>      UnsignedDecoder,
     "CUtlSymbolLarge" =>      StringDecoder,
     "CGlobalSymbol" => StringDecoder,
+    "CUtlBinaryBlock" => BinaryBlockDecoder,
     "Quaternion" => NoscaleDecoder,
     "CTransform" => NoscaleDecoder,
     "HSequence" => Unsigned64Decoder,

--- a/src/parser/src/second_pass/decoder.rs
+++ b/src/parser/src/second_pass/decoder.rs
@@ -28,6 +28,7 @@ pub enum Decoder {
     AmmoDecoder,
     QanglePresDecoder,
     GameModeRulesDecoder,
+    BinaryBlockDecoder,
 }
 #[derive(Debug, Clone)]
 pub struct QfMapper {
@@ -60,7 +61,14 @@ impl<'a> Bitreader<'a> {
             AmmoDecoder => Ok(Variant::U32(self.decode_ammo()?)),
             QanglePresDecoder => Ok(Variant::VecXYZ(self.decode_qangle_variant_pres()?)),
             GameModeRulesDecoder => Ok(Variant::Bool(self.decode_poly()?)),
+            BinaryBlockDecoder => Ok(Variant::String(self.decode_binary_block()?)),
         }
+    }
+
+    pub fn decode_binary_block(&mut self) -> Result<String, DemoParserError> {
+        let n = self.read_varint()? as usize;
+        let bytes = self.read_n_bytes(n)?;
+        Ok(String::from_utf8_lossy(&bytes).to_string())
     }
 
     pub fn decode_poly(&mut self) -> Result<bool, DemoParserError> {


### PR DESCRIPTION
Recent CS2 demos were failing with `EntityNotFound` / `IllegalPathOp` because two new basetypes aren't handled, which misaligns the bitstream.

Fix mirrors what the Go parser did:
- https://github.com/markus-wa/demoinfocs-golang/pull/646 (`CUtlBinaryBlock`)
- https://github.com/markus-wa/demoinfocs-golang/pull/653 (`CGlobalSymbol`)

Changes:
- `CGlobalSymbol` → `StringDecoder`
- New `BinaryBlockDecoder` for `CUtlBinaryBlock` (reads varint length + N bytes, returned as `Variant::String` via `from_utf8_lossy`)

Tested on a bunch of broken demos locally (Rust crate directly), all parse fine now. I don't use the JS/Python bindings so haven't tested those paths, but the change is purely in the core decoder so it should just work.

Heads up: `CUtlBinaryBlock` is really `Vec<u8>` so `from_utf8_lossy` is a bit of a hack. Didn't want to add a new `Variant::Bytes` just for this but happy to if you'd rather.

Closes #320, #321.