### PR TITLE
Fix EntityNotFound on demos with > 256 classes (patch 14154+)

### DIFF
--- a/src/parser/src/second_pass/entities.rs
+++ b/src/parser/src/second_pass/entities.rs
@@ -315,7 +315,12 @@ impl<'a> SecondPassParser<'a> {
         Ok(())
     }
     fn create_new_entity(&mut self, bitreader: &mut Bitreader, entity_id: &i32, _events_to_emit: &mut Vec<GameEventInfo>) -> Result<(), DemoParserError> {
-        let cls_id: u32 = bitreader.read_nbits(8)?;
+        // Class id width is dynamic: ceil(log2(num_classes + 1)). Hardcoded 8 bits
+        // capped at 256 classes and broke on patches with more (14154+), causing
+        // bitstream desync and cascading EntityNotFound errors. cls_by_id.len()
+        // already equals num_classes + 1 (see first_pass::parser::parse_class_info).
+        let cls_bits = (self.cls_by_id.len() as f32).log2().ceil() as u32;
+        let cls_id: u32 = bitreader.read_nbits(cls_bits)?;
         // Both of these are not used. Don't think they are interesting for the parser
         let _serial = bitreader.read_nbits(NSERIALBITS)?;
         let _unknown = bitreader.read_varint();


### PR DESCRIPTION
## Summary

`create_new_entity` hardcodes `bitreader.read_nbits(8)` for the class id, capping the parser at 256 classes. CS2 patch 14154 (and 14155) push the class table past that limit, so the wrong number of bits are consumed, the bitstream desyncs, and every subsequent entity update fails with `EntityNotFound`.

This is the root cause of the regression reported in #325 (and also explains why the symptoms in #321 only partially went away after #322 — that fix unblocked one part of the parse but didn't address the entity-creation desync that hit the next set of demos).

## Fix

Source 2 defines the class id width as `ceil(log2(num_classes + 1))`. We already know the class table at this point: `cls_by_id.len() == num_classes + 1` (see `first_pass::parser::parse_class_info`, which sizes it as `msg.classes.len() + 1`). So the width can be derived directly from the propagated class table — no extra plumbing needed.

```rust
// before
let cls_id: u32 = bitreader.read_nbits(8)?;

// after
let cls_bits = (self.cls_by_id.len() as f32).log2().ceil() as u32;
let cls_id: u32 = bitreader.read_nbits(cls_bits)?;
```

## Notes

- Considered using `self.cls_bits` (computed in `parse_server_info`), but it's `None` here in practice — entity packets arrive before `svc_ServerInfo` is dispatched in the second pass. Deriving from `cls_by_id.len()` is reliable because the class table is propagated from the first pass via `FirstPassOutput`.
- Width matches the existing log2 calculation in `parse_server_info` (which is otherwise unused).

## Testing

Local rebuild via `napi build --release`, dropped into a Node project, tested against 5 .rar archives spanning 12 .dem files, multiple servers and patches:

| Server | Patch | Before | After |
|--------|-------|--------|-------|
| Esplay | 14141 | ✅ | ✅ |
| ESL Match Server | 14141 | ✅ | ✅ |
| FACEIT | 14154 | ❌ EntityNotFound | ✅ |
| eBot | 14154 | ❌ EntityNotFound | ✅ |
| F05 | 14155 | ❌ EntityNotFound | ✅ |

All maps return populated `round_end` events and `parseTicks(["crosshair_code", "name"])` rows at last tick. Older 14141 demos continue to parse with no behavior change.

Happy to share repro `.dem` files privately if useful.

Fixes #325.