### PR TITLE
Fallback to zero when CMsgQAngle is missing

### DIFF
--- a/src/parser/src/second_pass/parser.rs
+++ b/src/parser/src/second_pass/parser.rs
@@ -262,14 +262,17 @@ impl<'a> SecondPassParser<'a> {
                 if let Some(Some(ent)) = self.entities.get_mut(entity_id as usize) {
                     let mut history = vec![];
                     for input in user_cmd.input_history {
+                        // view_angles may be absent on some entries; default the angle to (0, 0, 0)
+                        // rather than panicking, matching prost's default accessor behaviour.
+                        let view_angles = input.view_angles.clone().unwrap_or_default();
                         let ih = InputHistory {
                             player_tick_count: input.player_tick_count(),
                             player_tick_fraction: input.player_tick_fraction(),
                             render_tick_count: input.render_tick_count(),
                             render_tick_fraction: input.render_tick_fraction(),
-                            x: input.view_angles.expect("CsgoInputHistoryEntryPb has no CMsgQAngle").x(),
-                            y: input.view_angles.expect("CsgoInputHistoryEntryPb has no CMsgQAngle").y(),
-                            z: input.view_angles.expect("CsgoInputHistoryEntryPb has no CMsgQAngle").z(),
+                            x: view_angles.x(),
+                            y: view_angles.y(),
+                            z: view_angles.z(),
                         };
                         history.push(ih);
                     }


### PR DESCRIPTION
`view_angles` is optional (`Option<CMsgQAngle>`) in `CSGOInputHistoryEntryPB`, but
`parse_user_cmd` unwrapped it with `.expect()`. Some entries have no view angle, so it panics.
This defaults the missing angle to `(0, 0, 0)` (matching prost's default accessors) instead of crashing.
Reproduced on these matchmaking demos (seems tied to abnormal player input and/or players leaving):
- http://replay186.valve.net/730/003823181880316919951_0336506325.dem.bz2
- http://replay183.valve.net/730/003823628595570410268_1615802468.dem.bz2
- http://replay161.valve.net/730/003823645485529301103_0616202653.dem.bz2
- http://replay272.valve.net/730/003823259597750141338_1354270156.dem.bz2