### PR TITLE
feat(parser): expose live player roster as fallback for empty player_md

### DIFF
--- a/src/parser/src/parse_demo.rs
+++ b/src/parser/src/parse_demo.rs
@@ -32,6 +32,10 @@ pub struct DemoOutput {
     pub convars: AHashMap<String, String>,
     pub header: Option<AHashMap<String, String>>,
     pub player_md: Vec<PlayerEndMetaData>,
+    /// Live player roster from CCSPlayerController entities (final per-player state,
+    /// deduplicated by steamid). Populated even when the end-of-match scoreboard message
+    /// is absent (community/casual demos). Fallback when `player_md` is empty.
+    pub roster: Vec<PlayerEndMetaData>,
     pub game_events_counter: AHashSet<String>,
     pub uniq_prop_names: Vec<String>,
     pub projectiles: Vec<ProjectileRecord>,
@@ -322,6 +326,22 @@ impl<'a> Parser<'a> {
             chat_messages: second_pass_outputs.iter().flat_map(|x| x.chat_messages.clone()).collect(),
             item_drops: second_pass_outputs.iter().flat_map(|x| x.item_drops.clone()).collect(),
             player_md: second_pass_outputs.iter().flat_map(|x| x.player_md.clone()).collect(),
+            roster: {
+                // Second-pass segments are sorted by ascending tick (sort_by_key(ptr) above);
+                // each captures a player's state at its last tick. Dedup by steamid keeping the
+                // LAST entry -> final name/team (after side swaps / renames).
+                let mut by_sid: std::collections::BTreeMap<u64, PlayerEndMetaData> = std::collections::BTreeMap::new();
+                for o in second_pass_outputs.iter() {
+                    for p in &o.roster {
+                        if let Some(sid) = p.steamid {
+                            if sid != 0 {
+                                by_sid.insert(sid, p.clone());
+                            }
+                        }
+                    }
+                }
+                by_sid.into_values().collect()
+            },
             game_events: second_pass_outputs.iter().flat_map(|x| x.game_events.clone()).collect(),
             skins: second_pass_outputs.iter().flat_map(|x| x.skins.clone()).collect(),
             convars: second_pass_outputs.iter().flat_map(|x| x.convars.clone()).collect(),

--- a/src/parser/src/second_pass/parser.rs
+++ b/src/parser/src/second_pass/parser.rs
@@ -45,6 +45,10 @@ pub struct SecondPassOutput {
     pub convars: AHashMap<String, String>,
     pub header: Option<AHashMap<String, String>>,
     pub player_md: Vec<PlayerEndMetaData>,
+    /// Live player roster from CCSPlayerController entities (final per-player state).
+    /// Populated even when CCSUsrMsg_EndOfMatchAllPlayersData is absent (community/casual
+    /// demos), where `player_md` ends up empty. Use as a fallback when `player_md` is empty.
+    pub roster: Vec<PlayerEndMetaData>,
     pub game_events_counter: AHashSet<String>,
     pub uniq_prop_names: AHashSet<String>,
     pub prop_info: PropController,

--- a/src/parser/src/second_pass/parser_settings.rs
+++ b/src/parser/src/second_pass/parser_settings.rs
@@ -140,6 +140,15 @@ impl<'a> SecondPassParser<'a> {
             item_drops: self.item_drops,
             header: None,
             player_md: self.player_end_data,
+            roster: self
+                .players
+                .values()
+                .map(|p| PlayerEndMetaData {
+                    steamid: p.steamid,
+                    name: p.name.clone(),
+                    team_number: p.team_num.map(|t| t as i32),
+                })
+                .collect(),
             game_events_counter: self.game_events_counter,
             uniq_prop_names: self.uniq_prop_names,
             prop_info: PropController::new(vec![], vec![], AHashMap::default(), AHashMap::default(), false, &["none".to_string()], false),


### PR DESCRIPTION
 `DemoOutput.player_md` is built exclusively from the `CCSUsrMsg_EndOfMatchAllPlayersData` net message (parse_player_end_msg). Community / casual servers (is_valve_server = false)
  never emit that message, so `player_md` comes back empty even though the demo contains full gameplay and real players with valid steamids. Consumers that treat `player_md` as the
  match roster then report 0 players for such demos.

  A live roster is already tracked during the second pass in `SecondPassParser.players` (CCSPlayerController entities, filtered on steamid != 0, non-spectator, valid pawn handle)
  but was never exposed.

  Expose it as a separate `roster: Vec<PlayerEndMetaData>` on both SecondPassOutput and DemoOutput, keeping `player_md` strictly as the end-of-match scoreboard. In combine_outputs
  the per-segment rosters are deduplicated by steamid keeping the LAST observed state, so final team/name after side swaps and renames are reported. Consumers can fall back to
  `roster` when `player_md` is empty.

[  Fixes #332](https://github.com/LaihoE/demoparser/issues/332)