### PR TITLE
Serve `buttons` on demos that carry input in delta_data

### DIFF
--- a/src/parser/src/first_pass/prop_controller.rs
+++ b/src/parser/src/first_pass/prop_controller.rs
@@ -94,6 +94,7 @@ pub const GRENADE_X: u32 = 100100023;
 pub const GRENADE_Y: u32 = 100100024;
 pub const GRENADE_Z: u32 = 100100025;
 pub const INVENTORY_AS_IDS_BITMASK: u32 = 100100026;
+pub const BUTTON_MASK_ID: u32 = 100100027;
 
 #[derive(Clone, Debug)]
 pub struct PropController {

--- a/src/parser/src/maps.rs
+++ b/src/parser/src/maps.rs
@@ -167,6 +167,9 @@ pub static BASETYPE_DECODERS2: phf::Map<&'static str, Decoder> = phf_map! {
     "gamerulesmode_fix" => GameModeRulesDecoder,
 };
 
+/// User-facing name of the raw button mask prop.
+pub const BUTTONS_PROP: &str = "buttons";
+
 pub static BUTTONMAP: phf::Map<&'static str, u64> = phf_map! {
     "LEFT" => 1 << 9,
     "FORWARD" => 1 << 3,
@@ -225,6 +228,7 @@ pub static CUSTOM_PLAYER_PROP_IDS: phf::Map<&'static str, u32> = phf_map! {
     "usercmd_weapon_select" => USERCMD_WEAPON_SELECT,
     "usercmd_input_history" => USERCMD_INPUT_HISTORY_BASEID,
     "usercmd_subtick_moves" => USERCMD_SUBTICK_MOVES_BASEID,
+    "buttons" => BUTTON_MASK_ID,
 
 
 
@@ -260,6 +264,7 @@ pub static TYPEHM: phf::Map<&'static str, PropType> = phf_map! {
     "usercmd_consumed_server_angle_changes" => PropType::Player,
     "usercmd_input_history" => PropType::Custom,
     "usercmd_subtick_moves" => PropType::Custom,
+    "buttons" => PropType::Custom,
 
 
     "CCSPlayerPawn.CCSPlayer_MovementServices.m_nButtonDownMaskPrev" => PropType::Player,
@@ -902,7 +907,9 @@ pub static FRIENDLY_NAMES_MAPPING: phf::Map<&'static str, &'static str> = phf_ma
     "rank_if_tie" => "CCSPlayerController.m_iCompetitiveRankingPredicted_Tie",
     "mvps" => "CCSPlayerController.m_iMVPs",
     "active_weapon_original_owner" => "active_weapon_original_owner",
-    "buttons" => "CCSPlayerPawn.CCSPlayer_MovementServices.m_nButtonDownMaskPrev",
+    // Resolves to itself: the raw button mask is served by a custom prop that
+    // falls back to the usercmd button state when the pawn prop is absent.
+    "buttons" => "buttons",
     "team_surrendered" => "CCSTeam.m_bSurrendered",
     "team_rounds_total" => "CCSTeam.m_iScore",
     "team_name" => "CCSTeam.m_szTeamname",

--- a/src/parser/src/second_pass/collect_data.rs
+++ b/src/parser/src/second_pass/collect_data.rs
@@ -485,6 +485,13 @@ impl<'a> SecondPassParser<'a> {
             IS_AIRBORNE_ID => self.find_is_airborne(player),
             AGENT_SKIN_ID => self.find_agent_skin(player),
             USERCMD_INPUT_HISTORY_BASEID => self.get_prop_from_ent(&USERCMD_INPUT_HISTORY_BASEID, entity_id),
+            // The pawn button mask is not networked on demos that carry input
+            // in `CMsgServerUserCmd.delta_data`. Serve `buttons` through the
+            // same fallback the named button props already use.
+            BUTTON_MASK_ID => self
+                .get_button_mask(entity_id)
+                .map(Variant::U64)
+                .ok_or(PropCollectionError::ButtonsSpecialIDNone),
             GLOVE_PAINT_ID => self.find_glove_skin_id(entity_id),
             GLOVE_SKIN => self.find_glove_skin(entity_id),
             GLOVE_PAINT_SEED => self.find_glove_paint_seed(entity_id),

--- a/src/parser/src/second_pass/parser_settings.rs
+++ b/src/parser/src/second_pass/parser_settings.rs
@@ -6,6 +6,7 @@ use crate::first_pass::sendtables::Serializer;
 use crate::first_pass::stringtables::StringTable;
 use crate::first_pass::stringtables::UserInfo;
 use crate::maps::BUTTONMAP;
+use crate::maps::BUTTONS_PROP;
 use crate::second_pass::collect_data::ProjectileRecord;
 use crate::second_pass::decoder::QfMapper;
 use crate::second_pass::entities::Entity;
@@ -178,7 +179,10 @@ impl<'a> SecondPassParser<'a> {
 
         Ok(SecondPassParser {
             uniq_prop_names: AHashSet::default(),
-            parse_usercmd: contains_usercmd_prop(&first_pass_output.settings.wanted_player_props),
+            parse_usercmd: contains_usercmd_prop(
+                &first_pass_output.settings.wanted_player_props,
+                first_pass_output.prop_controller.special_ids.buttons.is_none(),
+            ),
             usercmd_baselines: AHashMap::default(),
             last_tick: 0,
             start_end_offset: start_end_offset,
@@ -358,6 +362,12 @@ pub fn create_huffman_lookup_table() -> Vec<(u8, u8)> {
     return huf2;
 }
 
-fn contains_usercmd_prop(names: &[String]) -> bool {
-    names.iter().any(|name| name.contains("usercmd") || BUTTONMAP.get(name.as_str()).is_some())
+/// Usercmd parsing is expensive, so only turn it on when something actually
+/// needs it. The button props are served from the pawn button mask whenever the
+/// demo networks it; only when it is absent do they need the usercmd fallback.
+fn contains_usercmd_prop(names: &[String], button_mask_absent: bool) -> bool {
+    names.iter().any(|name| {
+        name.contains("usercmd")
+            || (button_mask_absent && (BUTTONMAP.get(name.as_str()).is_some() || name == BUTTONS_PROP))
+    })
 }

--- a/src/parser/src/second_pass/usercmd_delta.rs
+++ b/src/parser/src/second_pass/usercmd_delta.rs
@@ -4,8 +4,16 @@
 //! Singular fields retain protobuf wire encoding except for wire type 7,
 //! which resets a field to its declared default. The repeated input-history
 //! and subtick fields use the replacement-list encoding observed in current
-//! CS2 demos. Unknown or malformed operations fail the whole delta so callers
-//! can keep the previous per-player baseline unchanged.
+//! CS2 demos. Unknown or malformed operations in `base` fail the whole delta
+//! so callers can keep the previous per-player baseline unchanged.
+//!
+//! The two repeated sub-lists are handled at their own granularity: they are
+//! self-contained and carry nothing the button, mouse or view-angle props read.
+//! Current CS2 demos emit list operations this decoder does not model yet (a
+//! non-sequential `index << 3 | 7` key), and failing the enclosing command on
+//! them discards the whole user command — measured at 23% of all commands on a
+//! July-2026 Valve demo, which is what makes `buttons` collapse on those demos.
+//! An unparsed sub-list therefore keeps its baseline value instead.
 
 use csgoproto::CBaseUserCmdExecutionNotes;
 use csgoproto::CInButtonStatePb;
@@ -325,7 +333,9 @@ pub(super) fn apply_delta(baseline: &CsgoUserCmdPb, delta_data: &[u8]) -> Option
     let mut next = baseline.clone();
 
     if !delta.input_history_delta.is_empty() {
-        next.input_history = decode_repeated(&delta.input_history_delta, MessageSchema::InputHistory)?;
+        if let Some(history) = decode_repeated(&delta.input_history_delta, MessageSchema::InputHistory) {
+            next.input_history = history;
+        }
     }
     replace_if_some(&mut next.attack1_start_history_index, delta.attack1_start_history_index);
     replace_if_some(&mut next.attack2_start_history_index, delta.attack2_start_history_index);
@@ -361,7 +371,9 @@ pub(super) fn apply_delta(baseline: &CsgoUserCmdPb, delta_data: &[u8]) -> Option
             base.execution_notes = Some(CBaseUserCmdExecutionNotes::decode(notes).ok()?);
         }
         if !delta_base.subtick_moves_delta.is_empty() {
-            base.subtick_moves = decode_repeated(&delta_base.subtick_moves_delta, MessageSchema::SubtickMove)?;
+            if let Some(moves) = decode_repeated(&delta_base.subtick_moves_delta, MessageSchema::SubtickMove) {
+                base.subtick_moves = moves;
+            }
         }
     }
 
@@ -402,9 +414,36 @@ mod tests {
     }
 
     #[test]
-    fn rejects_nonsequential_repeated_entries_without_mutating_baseline() {
+    fn keeps_baseline_input_history_when_the_list_encoding_is_not_understood() {
+        // base { buttons_pb { buttonstate1: 0x410 } } plus an input-history
+        // list whose first key is non-sequential, i.e. an operation this
+        // decoder does not model. The command must still apply.
+        let delta = [0x0a, 0x05, 0x1a, 0x03, 0x08, 0x90, 0x08, 0x12, 0x02, 0x0a, 0x00];
+        let baseline = CsgoUserCmdPb {
+            base: Some(csgoproto::CBaseUserCmdPb {
+                buttons_pb: Some(CInButtonStatePb {
+                    buttonstate1: Some(1),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            input_history: vec![Default::default()],
+            ..Default::default()
+        };
+
+        let command = apply_delta(&baseline, &delta).expect("base must still apply");
+        assert_eq!(command.base.unwrap().buttons_pb.unwrap().buttonstate1, Some(0x410));
+        // The sub-list is preserved, not cleared.
+        assert_eq!(command.input_history, baseline.input_history);
+        assert_eq!(baseline.input_history.len(), 1);
+    }
+
+    #[test]
+    fn rejects_malformed_base_without_mutating_baseline() {
+        // A truncated varint inside `base` is not recoverable — the whole
+        // delta is rejected so the caller keeps the previous baseline.
         let baseline = CsgoUserCmdPb::default();
-        let delta = [0x12, 0x02, 0x0a, 0x00];
+        let delta = [0x0a, 0x02, 0xff, 0xff];
         assert!(apply_delta(&baseline, &delta).is_none());
         assert_eq!(baseline, CsgoUserCmdPb::default());
     }


### PR DESCRIPTION
Follow-up to #343 / #344. On demos recorded since the July 2026 CS2 update the
raw `buttons` mask is still empty, even though 0.42.0 restores the named button
props (`FORWARD`, `FIRE`, …). Two separate causes, both measured on a
July-2026 Valve demo (1 045 771 user commands, 2 481 `weapon_fire` events).

## 1. 23% of all user commands are discarded

`apply_delta` returns `None` on any operation it does not model, and
`parse_user_cmd` then skips the command entirely. An instrumented build shows
this is not rare:

```
total=1045771  full=439  delta=1045332  no_baseline=0  delta_fail=245767   (23.5%)
```

Every single failure comes from one site — `decode_repeated` for the repeated
input-history list:

```
rep_nonseq=246426     (all other failure counters 0)
rep_nonseq schema=InputHistory field=3 wire=7
rep_nonseq schema=InputHistory field=4 wire=7
```

`decode_repeated` models the list as a strictly sequential rebuild from empty
(`index << 3 | 2`, `index == messages.len()`). Current demos also emit
`index << 3 | 7` keys at non-sequential indices.

**I have not worked out what that operation means.** Reading it as "entry
resets to its declared defaults" — the convention `sanitize_message` uses for
singular fields — does not hold: the indices are not sequential, so the list
looks like a sparse update against the baseline rather than a rebuild. If you
or anyone reading this knows the encoding, I would rather implement it properly
than route around it.

What this PR does instead is narrow the blast radius. The input-history and
subtick lists are self-contained, and they carry nothing the button, mouse or
view-angle props read — those live in `base`. Failing the enclosing command on
an unmodelled list operation throws all of that away. An unparsed sub-list now
keeps its baseline value; a malformed `base` still fails the whole delta, so
the fail-closed contract is intact where it actually protects the caller.

This changes the contract that
`rejects_nonsequential_repeated_entries_without_mutating_baseline` pinned, so I
replaced it with two tests: one pinning that an unparsed sub-list preserves its
baseline while `base` still applies, one pinning that a malformed `base` still
rejects the delta.

## 2. `buttons` points at a prop these demos no longer network

`FRIENDLY_NAMES_MAPPING["buttons"]` resolved to
`CCSPlayerPawn.CCSPlayer_MovementServices.m_nButtonDownMaskPrev`. On affected
demos that prop is absent from the send tables entirely, so no `PropInfo` and
no `special_ids.buttons` are ever created and the column cannot materialise —
no collect-time fallback can help. Requesting the long name directly:

| demo | returned columns |
|---|---|
| affected | `[]` |
| healthy | `['CCSPlayerPawn.CCSPlayer_MovementServices.m_nButtonDownMaskPrev']` |

`buttons` becomes a custom prop served through the `get_button_mask` helper
0.42.0 already added for the named button props: pawn prop first, usercmd
button state second. Requesting the long name still goes down the old path
unchanged.

Usercmd parsing is expensive, so `contains_usercmd_prop` opts in for the button
props only when the pawn prop is missing. Demos that still network it pay
nothing.

## Validation

Oracle: `IN_ATTACK` (bit 0) set at the shooter's own `weapon_fire` tick.

| parser | `buttons` column | IN_ATTACK@weapon_fire |
|---|---|---|
| 0.42.0 | absent | — (via `usercmd_buttonstate_1`: 1424/2458 = 57.9%) |
| this PR | present | **2193/2481 = 88.4%** |

As a cross-check I decoded the same `delta_data` payloads with an independent
pure-Python implementation written before 0.42.0 existed. It reports
**2193/2481** on this demo — the same events, not just the same rate.

Two healthy demos are unchanged before/after:

| demo | rows | non-null | non-zero |
|---|---|---|---|
| community (324 MB) | 1 593 520 | 1 588 362 | 1 186 079 |
| pro (468 MB) | 2 121 550 | 2 118 624 | 1 550 873 |

Identical per-bit rates on both. Interleaved A/B, 3 runs each on the community
demo: 1.30–1.36 s before, 1.33–1.35 s after.

`cargo test --release`: 338 passed, 0 failed.

## Repro demo

Happy to share the affected demo — I offered one on #340 earlier
(issuecomment-4967700006) since the ones you had did not reproduce. Just say
where to send it.
